### PR TITLE
Added MPQ Compression support via AddFileFromDiskWithCompression

### DIFF
--- a/src/StormLibSharp/MpqArchive.cs
+++ b/src/StormLibSharp/MpqArchive.cs
@@ -159,6 +159,14 @@ namespace StormLibSharp
                 throw new Win32Exception();
         }
 
+        public void AddFileFromDiskWithCompression(string filePath, string archiveName, MpqCompressionTypeFlags compressionFlags)
+        {
+            VerifyHandle();
+
+            if(!NativeMethods.SFileAddFileEx(_handle, filePath, archiveName, (uint)SFileAddFileFlags.MPQ_FILE_COMPRESS, (uint)compressionFlags, (uint)compressionFlags))
+                throw new Win32Exception();
+        }
+
         public void Compact(string listfile)
         {
             VerifyHandle();

--- a/src/StormLibSharp/Native/MPQCompressionTypeFlags.cs
+++ b/src/StormLibSharp/Native/MPQCompressionTypeFlags.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StormLibSharp
+{
+    /// <summary>
+    /// Compression types for multiple compressions
+    /// </summary>
+    [Flags]
+    public enum MpqCompressionTypeFlags : uint
+    {
+        /// <summary>
+        /// Huffmann compression (used on WAVE files only)
+        /// </summary>
+        MPQ_COMPRESSION_HUFFMANN = 0x01,
+
+        /// <summary>
+        /// ZLIB compression
+        /// </summary>
+        MPQ_COMPRESSION_ZLIB = 0x02,
+
+        /// <summary>
+        ///  PKWARE DCL compression
+        /// </summary>
+        MPQ_COMPRESSION_PKWARE = 0x08,
+
+        /// <summary>
+        /// BZIP2 compression (added in Warcraft III)
+        /// </summary>
+        MPQ_COMPRESSION_BZIP2 = 0x10,
+
+        /// <summary>
+        /// Sparse compression (added in Starcraft 2)
+        /// </summary>
+        MPQ_COMPRESSION_SPARSE = 0x20,
+
+        /// <summary>
+        /// IMA ADPCM compression (mono)
+        /// </summary>
+        MPQ_COMPRESSION_ADPCM_MONO = 0x40,
+
+        /// <summary>
+        /// IMA ADPCM compression (stereo)
+        /// </summary>
+        MPQ_COMPRESSION_ADPCM_STEREO = 0x80,
+
+        /// <summary>
+        /// LZMA compression. Added in Starcraft 2. This value is NOT a combination of flags.
+        /// </summary>
+        MPQ_COMPRESSION_LZMA = 0x12,
+
+        /// <summary>
+        /// Same compression
+        /// </summary>
+        MPQ_COMPRESSION_NEXT_SAME = 0xFFFFFFFF
+    }
+}

--- a/src/StormLibSharp/Native/SFileAddFileFlags.cs
+++ b/src/StormLibSharp/Native/SFileAddFileFlags.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace StormLibSharp.Native
+{
+    /// <summary>
+    /// Flags enumeration for SFileAddFile and SFileAddFileEx.
+    /// </summary>
+    [Flags]
+    internal enum SFileAddFileFlags : uint
+    {
+        /// <summary>
+        /// Implode method (By PKWARE Data Compression Library)
+        /// </summary>
+        MPQ_FILE_IMPLODE = 0x00000100,
+
+        /// <summary>
+        /// Compress methods (By multiple methods)
+        /// </summary>
+        MPQ_FILE_COMPRESS = 0x00000200,
+
+        /// <summary>
+        /// Indicates whether file is encrypted 
+        /// </summary>
+        MPQ_FILE_ENCRYPTED = 0x00010000,
+
+        /// <summary>
+        /// File decryption key has to be fixed
+        /// </summary>
+        MPQ_FILE_FIX_KEY = 0x00020000,
+
+        /// <summary>
+        /// The file is a patch file. Raw file data begin with TPatchInfo structure
+        /// </summary>
+        MPQ_FILE_PATCH_FILE = 0x00100000,
+
+        /// <summary>
+        /// File is stored as a single unit, rather than split into sectors (Thx, Quantam)
+        /// </summary>
+        MPQ_FILE_SINGLE_UNIT = 0x01000000,
+
+        /// <summary>
+        /// File is a deletion marker. Used in MPQ patches, indicating that the file no longer exists.
+        /// </summary>
+        MPQ_FILE_DELETE_MARKER = 0x02000000,
+
+        /// <summary>
+        /// File has checksums for each sector.
+        /// </summary>
+        MPQ_FILE_SECTOR_CRC = 0x04000000
+    }
+}

--- a/src/StormLibSharp/StormLibSharp.csproj
+++ b/src/StormLibSharp/StormLibSharp.csproj
@@ -46,8 +46,10 @@
     <Compile Include="MpqFileStream.cs" />
     <Compile Include="Native\Callbacks.cs" />
     <Compile Include="Native\MpqArchiveSafeHandle.cs" />
+    <Compile Include="Native\MpqCompressionTypeFlags.cs" />
     <Compile Include="Native\MpqFileSafeHandle.cs" />
     <Compile Include="Native\NativeMethods.cs" />
+    <Compile Include="Native\SFileAddFileFlags.cs" />
     <Compile Include="Native\SFileInfoClass.cs" />
     <Compile Include="Native\SFileOpenArchiveFlags.cs" />
     <Compile Include="Native\Win32Methods.cs" />


### PR DESCRIPTION
Internally it calls the original unreferenced stormlib binding
SFileAddFileEx. With SFileAddFileFlags.MPQ_FILE_COMPRESS set and the
provided MpqCompressionTypeFlags from the method parameter list.

This is a pretty important feature for production. Without this feature
it is not reasonable to use this Stormlib library to construct MPQs, the
sizes will be too large.